### PR TITLE
QCOS-3078 kirk SDK添加AP 端口的创建时间&更新时间

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # vNext
 - 修复BUG:非nil空slice未被包含在发送request body中
-
+- Add port created time and updated time
 # Release 0.1.0
 - Initial release

--- a/kirksdk/qcos_api.go
+++ b/kirksdk/qcos_api.go
@@ -531,6 +531,8 @@ type ApPortInfo struct {
 	SessionTmoSec   int               `json:"sessionTimeoutSec"`
 	ProxyOpts       ApProxyOpts       `json:"proxyOptions"`
 	HealthCheckOpts ApHealthCheckOpts `json:"healthCheck"`
+	CreatedAt       time.Time         `json:"createdAt"`
+	UpdatedAt       time.Time         `json:"updatedAt"`
 	Backends        []struct {
 		Stack         string `json:"stack"`
 		Service       string `json:"service"`


### PR DESCRIPTION
RT，API如下，返回的端口信息中加入createdAt和updatedAt字段。

```
ports:[
  {
    "frontendPort": "80",
   .... 
   "createdAt":"2016-11-11T15:55:18.27183+08:00", # 端口创建时间
   "updatedAt":"2016-11-11T15:55:18.27183+08:00" # 端口更新时间
  },
 ...