### PR TITLE
QCOS-3008 Fix bug: Empty slice is not included in request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+# vNext
+- 修复BUG:非nil空slice未被包含在发送request body中
+
 # Release 0.1.0
 - Initial release

--- a/kirksdk/qcos_client.go
+++ b/kirksdk/qcos_client.go
@@ -979,7 +979,7 @@ func (p *qcosClientImp) CreateJob(ctx context.Context, args CreateJobArgs) (err 
 // POST /v3/jobs/<name>
 func (p *qcosClientImp) UpdateJob(ctx context.Context, name string, args UpdateJobArgs) (err error) {
 	url := fmt.Sprintf("%s/v3/jobs/%s", p.host, name)
-	err = p.client.Call(ctx, nil, "POST", url)
+	err = p.client.CallWithJson(ctx, nil, "POST", url, args)
 	return
 }
 

--- a/kirksdk/qcos_client_test.go
+++ b/kirksdk/qcos_client_test.go
@@ -551,3 +551,75 @@ func TestServices(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedRet, info)
 }
+
+func TestUpdateService(t *testing.T) {
+	expectedUrl := "/v3/stacks/stack/services/service"
+	expectedMethod := "POST"
+	expectedBody := `{"manualUpdate":false,"metadata":["a=a1","b=b2"],"spec":{"command":[],"entryPoint":[],"envs":[],"hosts":[],"logCollectors":[],"gpuUUIDs":[],"autoRestart":"always","image":"testimage","stopGraceSec":1,"workDir":"testdir","unitType":"testunittype"},"updateParallelism":2}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, expectedUrl, r.URL.Path)
+		assert.Equal(t, expectedMethod, r.Method)
+		body, err := ioutil.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedBody, string(body))
+		fmt.Fprintln(w, "")
+	}))
+	defer ts.Close()
+
+	client := NewQcosClient(QcosConfig{
+		Host: ts.URL,
+	})
+
+	args := UpdateServiceArgs{
+		ManualUpdate: false,
+		Metadata:     []string{"a=a1", "b=b2"},
+		Spec: ServiceSpec{
+			AutoRestart:   "always",
+			Command:       []string{},
+			EntryPoint:    []string{},
+			Envs:          []string{},
+			Hosts:         []string{},
+			Image:         "testimage",
+			LogCollectors: []LogCollectorSpec{},
+			StopGraceSec:  1,
+			WorkDir:       "testdir",
+			UnitType:      "testunittype",
+			GpuUUIDs:      []string{},
+		},
+		UpdateParallelism: 2,
+	}
+
+	err := client.UpdateService(context.TODO(), "stack", "service", args)
+	assert.NoError(t, err)
+}
+
+func TestUpdateJob(t *testing.T) {
+	expectedUrl := "/v3/jobs/default"
+	expectedMethod := "POST"
+	expectedBody := `{"metadata":[],"runAt":"testrunat","timeout":3000,"mode":"testmode"}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, expectedUrl, r.URL.Path)
+		assert.Equal(t, expectedMethod, r.Method)
+		body, err := ioutil.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedBody, string(body))
+		fmt.Fprintln(w, "")
+	}))
+	defer ts.Close()
+
+	client := NewQcosClient(QcosConfig{
+		Host: ts.URL,
+	})
+
+	args := UpdateJobArgs{
+		Spec:     map[string]JobTaskSpec{},
+		Metadata: []string{},
+		RunAt:    "testrunat",
+		Timeout:  3000,
+		Mode:     "testmode",
+	}
+	err := client.UpdateJob(context.TODO(), "default", args)
+	assert.NoError(t, err)
+}

--- a/kirksdk/qcos_json.go
+++ b/kirksdk/qcos_json.go
@@ -1,0 +1,95 @@
+package kirksdk
+
+import (
+	"encoding/json"
+)
+
+func (p ServiceSpec) MarshalJSON() ([]byte, error) {
+	type Alias ServiceSpec
+	return json.Marshal(&struct {
+		Command       *[]string           `json:"command,omitempty"`
+		EntryPoint    *[]string           `json:"entryPoint,omitempty"`
+		Envs          *[]string           `json:"envs,omitempty"`
+		Hosts         *[]string           `json:"hosts,omitempty"`
+		LogCollectors *[]LogCollectorSpec `json:"logCollectors,omitempty"`
+		GpuUUIDs      *[]string           `json:"gpuUUIDs,omitempty"`
+		*Alias
+	}{
+		Command:       stringS2P(p.Command),
+		EntryPoint:    stringS2P(p.EntryPoint),
+		Envs:          stringS2P(p.Envs),
+		Hosts:         stringS2P(p.Hosts),
+		LogCollectors: logCollectorSpecS2P(p.LogCollectors),
+		GpuUUIDs:      stringS2P(p.GpuUUIDs),
+		Alias:         (*Alias)(&p),
+	})
+}
+
+func (p JobTaskSpec) MarshalJSON() ([]byte, error) {
+	type Alias JobTaskSpec
+	return json.Marshal(&struct {
+		Command       *[]string           `json:"command,omitempty"`
+		EntryPoint    *[]string           `json:"entryPoint,omitempty"`
+		Envs          *[]string           `json:"envs,omitempty"`
+		Hosts         *[]string           `json:"hosts,omitempty"`
+		LogCollectors *[]LogCollectorSpec `json:"logCollectors,omitempty"`
+		*Alias
+	}{
+		Command:       stringS2P(p.Command),
+		EntryPoint:    stringS2P(p.EntryPoint),
+		Envs:          stringS2P(p.Envs),
+		Hosts:         stringS2P(p.Hosts),
+		LogCollectors: logCollectorSpecS2P(p.LogCollectors),
+		Alias:         (*Alias)(&p),
+	})
+}
+
+func (p UpdateJobArgs) MarshalJSON() ([]byte, error) {
+	type Alias UpdateJobArgs
+	return json.Marshal(&struct {
+		Metadata *[]string `json:"metadata,omitempty"`
+		*Alias
+	}{
+		Metadata: stringS2P(p.Metadata),
+		Alias:    (*Alias)(&p),
+	})
+}
+
+func (p JobTaskSpecEx) MarshalJSON() ([]byte, error) {
+	type Alias JobTaskSpecEx
+	return json.Marshal(&struct {
+		LogCollectors *[]LogCollectorSpec `json:"logCollectors,omitempty"`
+		Command       *[]string           `json:"command,omitempty"`
+		EntryPoint    *[]string           `json:"entryPoint,omitempty"`
+		Envs          *[]string           `json:"envs,omitempty"`
+		Hosts         *[]string           `json:"hosts,omitempty"`
+		Deps          *[]string           `json:"deps,omitempty"`
+		*Alias
+	}{
+		LogCollectors: logCollectorSpecS2P(p.LogCollectors),
+		Command:       stringS2P(p.Command),
+		EntryPoint:    stringS2P(p.EntryPoint),
+		Envs:          stringS2P(p.Envs),
+		Hosts:         stringS2P(p.Hosts),
+		Deps:          stringS2P(p.Deps),
+		Alias:         (*Alias)(&p),
+	})
+}
+
+//-----------------------------------------------------------------
+
+func stringS2P(s []string) *[]string {
+	if s == nil {
+		return nil
+	}
+
+	return &s
+}
+
+func logCollectorSpecS2P(s []LogCollectorSpec) *[]LogCollectorSpec {
+	if s == nil {
+		return nil
+	}
+
+	return &s
+}

--- a/kirksdk/qcos_json_test.go
+++ b/kirksdk/qcos_json_test.go
@@ -1,0 +1,102 @@
+package kirksdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestServiceSpecMarshal(t *testing.T) {
+	spec := ServiceSpec{
+		AutoRestart: "always",
+		Command:     []string{},
+		EntryPoint:  nil,
+		Envs:        []string{"a=a1", "b=b1"},
+		// Host:	nil
+		Image:         "Image",
+		LogCollectors: []LogCollectorSpec{},
+		StopGraceSec:  1,
+		WorkDir:       "~/",
+		UnitType:      "unittype",
+		GpuUUIDs:      []string{},
+	}
+
+	testMarshal(
+		t,
+		spec,
+		`{"command":[],"envs":["a=a1","b=b1"],"logCollectors":[],"gpuUUIDs":[],"autoRestart":"always","image":"Image","stopGraceSec":1,"workDir":"~/","unitType":"unittype"}`,
+	)
+}
+
+func TestJobTaskSpecMarshal(t *testing.T) {
+	spec := JobTaskSpec{
+		Image:         "testimage",
+		Command:       nil,
+		EntryPoint:    []string{},
+		Envs:          []string{},
+		Hosts:         []string{},
+		LogCollectors: []LogCollectorSpec{},
+		WorkDir:       "testworkdir",
+		InstanceNum:   2,
+		UnitType:      "testunittype",
+	}
+
+	testMarshal(
+		t,
+		spec,
+		`{"entryPoint":[],"envs":[],"hosts":[],"logCollectors":[],"image":"testimage","workDir":"testworkdir","instanceNum":2,"unitType":"testunittype"}`,
+	)
+}
+
+func TestUpdateJobArgsMarshal(t *testing.T) {
+	args := UpdateJobArgs{
+		Spec:     map[string]JobTaskSpec{},
+		Metadata: []string{},
+		RunAt:    "testrunat",
+		Timeout:  3000,
+		Mode:     "testmode",
+	}
+
+	testMarshal(
+		t,
+		args,
+		`{"metadata":[],"runAt":"testrunat","timeout":3000,"mode":"testmode"}`,
+	)
+}
+
+func TestJobTaskSpecExMarshal(t *testing.T) {
+	specEx := JobTaskSpecEx{
+		WorkDir: "",
+		LogCollectors: []LogCollectorSpec{
+			LogCollectorSpec{
+				Directory: "testdir1",
+				Patterns:  []string{"p1", "p2"},
+			},
+		},
+		Command:     []string{},
+		EntryPoint:  []string{},
+		Envs:        []string{},
+		Hosts:       []string{},
+		UnitType:    "testunittype",
+		Deps:        []string{},
+		InstanceNum: 3,
+	}
+
+	testMarshal(
+		t,
+		&specEx,
+		`{"logCollectors":[{"directory":"testdir1","patterns":["p1","p2"]}],"command":[],"entryPoint":[],"envs":[],"hosts":[],"deps":[],"unitType":"testunittype","instanceNum":3}`,
+	)
+}
+
+func testMarshal(t *testing.T, input interface{}, expected string) {
+	bytes, err := json.Marshal(input)
+	assert.Nil(t, err)
+
+	actual := string(bytes)
+
+	fmt.Println(actual)
+
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
BUG描述：
type Info
{ foo []string `json:"foo,omitempty"` }
当 foo 为 [] 时，request中没有包含foo。导致在调用Update API的时候无法清空foo

修复说明：
重载Info的MarshalJSON方法，用foo *[]string替代原有foo。