### PR TITLE
QCOS-3141添加outward IP类型接入点

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # vNext
+- 添加outward IP类型接入点
 
 # Release 1.1.0
 - AccountClient 相关 API 使用 appd V3 接口

--- a/kirksdk/qcos_api.go
+++ b/kirksdk/qcos_api.go
@@ -328,6 +328,7 @@ const (
 	ApTypePublicIPStr  = "PUBLIC_IP"
 	ApTypePrivateIPStr = "INTERNAL_IP"
 	ApTypeDomainStr    = "DOMAIN"
+	ApTypeOutwardIPStr = "OUTWARD_IP"
 )
 
 type Status string


### PR DESCRIPTION
添加outward IP类型接入点，仅供具有物理内网访问权限的app使用。