### PR TITLE
QCOS-3192 SDK添加禁用/启用AP端口的API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # vNext
 - 添加outward IP类型接入点
+- 添加禁用/启用AP端口的API，并在查看/搜索AP的API返回的端口信息中返回端口的启用状态（启用/禁用）。
+
 
 # Release 1.1.0
 - AccountClient 相关 API 使用 appd V3 接口

--- a/kirksdk/qcos_api.go
+++ b/kirksdk/qcos_api.go
@@ -228,6 +228,22 @@ type QcosClient interface {
 	DeleteApPortRange(
 		ctx context.Context, apid string, fromPort string, toPort string) (err error)
 
+	// POST /v3/aps/<apid>/<port>/enable
+	EnableApPort(
+		ctx context.Context, apid string, port string) (err error)
+
+	// POST /v3/aps/<apid>/<port>/disable
+	DisableApPort(
+		ctx context.Context, apid string, port string) (err error)
+
+	// POST /v3/aps/<apid>/portrange/<from>/<to>/enable
+	EnableApPortRange(
+		ctx context.Context, apid string, fromPort string, toPort string) (err error)
+
+	// POST /v3/aps/<apid>/portrange/<from>/<to>/disable
+	DisableApPortRange(
+		ctx context.Context, apid string, fromPort string, toPort string) (err error)
+
 	// DELETE /v3/aps/<apid>
 	DeleteAp(ctx context.Context, apid string) (err error)
 
@@ -584,6 +600,7 @@ type ApPortInfo struct {
 	SessionTmoSec   int               `json:"sessionTimeoutSec"`
 	ProxyOpts       ApProxyOpts       `json:"proxyOptions"`
 	HealthCheckOpts ApHealthCheckOpts `json:"healthCheck"`
+	Enabled         bool              `json:"enabled"`
 	CreatedAt       time.Time         `json:"createdAt"`
 	UpdatedAt       time.Time         `json:"updatedAt"`
 	Backends        []struct {

--- a/kirksdk/qcos_client.go
+++ b/kirksdk/qcos_client.go
@@ -1065,6 +1065,38 @@ func (p *qcosClientImp) DeleteApPortRange(
 	return
 }
 
+// POST /v3/aps/<apid>/<port>/enable
+func (p *qcosClientImp) EnableApPort(
+	ctx context.Context, apid string, port string) (err error) {
+	url := fmt.Sprintf("%s/v3/aps/%s/%s/enable", p.host, apid, port)
+	err = p.client.CallWithJson(ctx, nil, "POST", url, nil)
+	return
+}
+
+// POST /v3/aps/<apid>/<port>/disable
+func (p *qcosClientImp) DisableApPort(
+	ctx context.Context, apid string, port string) (err error) {
+	url := fmt.Sprintf("%s/v3/aps/%s/%s/disable", p.host, apid, port)
+	err = p.client.CallWithJson(ctx, nil, "POST", url, nil)
+	return
+}
+
+// POST /v3/aps/<apid>/portrange/<from>/<to>/enable
+func (p *qcosClientImp) EnableApPortRange(
+	ctx context.Context, apid string, fromPort string, toPort string) (err error) {
+	url := fmt.Sprintf("%s/v3/aps/%s/portrange/%s/%s/enable", p.host, apid, fromPort, toPort)
+	err = p.client.CallWithJson(ctx, nil, "POST", url, nil)
+	return
+}
+
+// POST /v3/aps/<apid>/portrange/<from>/<to>/disable
+func (p *qcosClientImp) DisableApPortRange(
+	ctx context.Context, apid string, fromPort string, toPort string) (err error) {
+	url := fmt.Sprintf("%s/v3/aps/%s/portrange/%s/%s/disable", p.host, apid, fromPort, toPort)
+	err = p.client.CallWithJson(ctx, nil, "POST", url, nil)
+	return
+}
+
 // GET  /v3/aps/<apid>/<port>/healthcheck
 func (p *qcosClientImp) GetHealthcheck(ctx context.Context, apid string, port string) (ret map[string]string, err error) {
 	url := fmt.Sprintf("%s/v3/aps/%s/%s/healthcheck", p.host, apid, port)


### PR DESCRIPTION
添加禁用/启用AP端口的API，并在查看/搜索AP的API返回的端口信息中返回端口的启用状态（启用/禁用）。