### PR TITLE
QCOS-3233查看服务给出AP信息

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # vNext
 - 添加outward IP类型接入点
 - 添加禁用/启用AP端口的API，并在查看/搜索AP的API返回的端口信息中返回端口的启用状态（启用/禁用）。
-
+- 查看服务时，给出与该服务关联的AP端口信息。
 
 # Release 1.1.0
 - AccountClient 相关 API 使用 appd V3 接口

--- a/kirksdk/qcos_api.go
+++ b/kirksdk/qcos_api.go
@@ -404,6 +404,7 @@ type ServiceInfo struct {
 	UpdatingProgress  int               `json:"updatingProgress"`
 	CreatedAt         time.Time         `json:"createdAt"`
 	UpdatedAt         time.Time         `json:"updatedAt"`
+	ApPorts           []ServiceApPort   `json:"apPorts"`
 }
 
 type ServiceExportInfo struct {
@@ -539,6 +540,19 @@ type ResizeContainerExecTermArgs struct {
 
 type StartContainerExecArgs struct {
 	Mode string `json:"mode"`
+}
+
+// AP ports related to a service.
+type ServiceApPort struct {
+	ApID         string   `json:"apId"`
+	Type         string   `json:"type"`
+	IP           string   `json:"ip,omitempty"`
+	Domain       string   `json:"domain,omitempty"`
+	UserDomains  []string `json:"userDomains,omitempty"`
+	FrontendPort string   `json:"frontendPort"`
+	BackendPort  string   `json:"backendPort"`
+	Proto        string   `json:"proto"`
+	Enabled      bool     `json:"enabled"`
 }
 
 type CreateApArgs struct {

--- a/kirksdk/qcos_client_test.go
+++ b/kirksdk/qcos_client_test.go
@@ -248,6 +248,18 @@ func TestServicesInspect(t *testing.T) {
 				Name:      "v2",
 			},
 		},
+		ApPorts: []ServiceApPort{
+			ServiceApPort{
+				ApID:         "1000001",
+				Type:         "DOMAIN",
+				Domain:       "abcd1234",
+				UserDomains:  []string{"www.aa.com"},
+				FrontendPort: "80",
+				BackendPort:  "8080",
+				Proto:        "HTTP",
+				Enabled:      true,
+			},
+		},
 	}
 	ret := `{
     "containerIps": [
@@ -350,7 +362,17 @@ func TestServicesInspect(t *testing.T) {
             "name": "v2",
 			"unitType": "SSD1_16G"
         }
-    ]
+    ],
+    "apPorts": [{
+    	"apId": "1000001",
+    	"type": "DOMAIN",
+    	"domain": "abcd1234",
+    	"userDomains": ["www.aa.com"],
+    	"frontendPort": "80",
+    	"backendPort": "8080",
+    	"proto": "HTTP",
+    	"enabled": true
+    	}]
 }`
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, expectedUrl, r.URL.Path)


### PR DESCRIPTION
查看服务时，给出与该服务关联的接入点监听端口。
返回格式
```
"apPorts":[{
  "apId": "10000001",
   "frontendPort": "80",
   "backendPort": "8080",
   "ip": "1.2.3.4",
   "type": "PUBLIC_IP",
   "proto": "TCP",
   "enabled":true
},{
    "apId": "1000002", //string
   "frontendPort": "80", //string
   "backendPort": "8080", //string
   "domain":"abcd1234.nq.cloudappl.com",
    "userDomains": ["www.example.com"],
   "type": "DOMAIN",
   "proto": "HTTP",
   "enabled":true
},...]
```