### PR TITLE
QCOS-3182 添加接入点enabled字段

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # vNext
 
+
 # Release 2.4.0
+- AP详情添加enabled字段，表示这个AP是否已被管理员禁用
 - 新增app配额查询接口
 - 新增 app spec 申请接口
 - CreateServiceVolume/SyncCreateServiceVolume 即将下线

--- a/kirksdk/qcos_api.go
+++ b/kirksdk/qcos_api.go
@@ -668,6 +668,7 @@ type FullApInfo struct {
 	Provider    string    `json:"provider"`
 	Bandwidth   int       `json:"bandwidthMbps"`
 	Traffic     int       `json:"trafficBytes"`
+	Enabled     bool      `json:"enabled"`
 	UserDomains []string  `json:"userDomains,omitempty"`
 	Host        string    `json:"host,omitempty"`
 	UnitType    string    `json:"unitType,omitempty"`


### PR DESCRIPTION
见CHANGELOG,AP详情中加入enabled字段，表示该接入点是否启用。 true表示启用，false表示被管理员禁用。